### PR TITLE
27 dill required in multiple notebooks but not stated in dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -21,6 +21,7 @@ cycler==0.12.1
 debugpy==1.8.0
 decorator==5.1.1
 defusedxml==0.7.1
+dill==0.3.7
 exceptiongroup==1.1.3
 executing==2.0.0
 fastjsonschema==2.18.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -98,6 +98,7 @@ six==1.16.0
 sniffio==1.3.0
 soupsieve==2.5
 stack-data==0.6.3
+statsmodels
 tenacity==8.2.3
 terminado==0.17.1
 tinycss2==1.2.1


### PR DESCRIPTION
### All Submissions:

* [Y ] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [Y ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ Y] Does your PR link to an issue?


This PR addresses #27 by adding dill and statsmodel modules to the requirements_dev.txt used for developing the notebooks.
