### PR TITLE
Add Git Versioning Docs

### DIFF
--- a/.github/RELEASE_GUIDE.md
+++ b/.github/RELEASE_GUIDE.md
@@ -1,0 +1,50 @@
+# NMDC_NOTEBOOKS Release Guide
+
+## Introduction
+The following is a set of guidelines for generating releases for nmdc_notebooks. This documentation is solely for the maintainers of the nmdc_notebooks repo. A release is generated on the first business day of every month if there have been pull requests merged into main. If there are no changes on main, then no release is generated.
+
+## Preparing for Release
+
+### Versioning Scheme
+This project adheres to the semantic versioning as outlined by [semver.org](https://semver.org/): MAJOR.MINOR.PATCH
+* Patch: e.g. 1.0.1 -> 1.0.2 
+   * indicates bug fixes and trivial updates
+   * fixing notebook bugs or typos are examples of patch-level changes.
+* Minor: e.g. 1.0.2 -> 1.1.0 
+   * indicates change to functionality but is still backwards compatible 
+   * examples include functionality changes, updates, adding new functionality, and potentially removing functionality depending on the degree of it.
+   * Adding new notebooks and documentation and adding functionality to notebooks (such as adding a new visual, etc.) are examples of minor changes.
+* Major: e.g. 1.1.0 -> 2.0.0 
+   * changes the introduce breaking functionality and are not backwards compatible 
+   * examples include removing deprecated code or introducing a new architecture.
+   * Major updates to the notebooks architecture (such as major api endpoints and schema traversals) and removing notebooks are considered major changes.
+
+## Release Steps 
+Use [Github's documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to create a release by clicking on `Releases` on the repo's main page.
+1. Make a new tag when drafting a new release that follows the convention `v.1.0.0`
+2. Set the target branch to `main`
+3. Set the previous tag as the previous release number. e.g. `v.1.2.0`
+4. Generate release notes so a list of all the merge requests and contributors auto-populates.
+5. Save as draft release until ready to release or publish if ready.
+   * Recommend saving as draft while updating the `CHANGELOG.md`. 
+
+## Post Release Steps
+* After publishing, update the `CHANGELOG.md`, create a PR with changelog updates, review, and merge.
+
+### Branching Strategy to update CHANGELOG.md
+A release branch is a branch created for preparing for the release. This is the branch used to update the CHANGELOG.md that goes with the release
+* A release branch should be named as `release-<version>`. For examples `release-v1.1.0`. 
+* Update any release documentation (i.e. the CHANGELOG.md) on this branch to prepare for a release. 
+* Create a PR when ready for release
+
+### Updating the CHANGELOG.md
+The `CHANGELOG.md` is formatted based on [Keep a Changelog](http://keepachangelog.com/)
+The change log is meant to be easily understood by humans. It is formatted with the types of changes as subheadings for each release:
+* Added
+* Changed
+* Deprecated
+* Removed
+* Fixed
+* Security
+The newest release should be at the top of the `CHANGELOG.md` with older releases below.
+

--- a/.github/RELEASE_GUIDE.md
+++ b/.github/RELEASE_GUIDE.md
@@ -1,29 +1,29 @@
 # NMDC_NOTEBOOKS Release Guide
 
 ## Introduction
-The following is a set of guidelines for generating releases for nmdc_notebooks. This documentation is solely for the maintainers of the nmdc_notebooks repo. A release is generated on the first business day of every month if there have been pull requests merged into main. If there are no changes on main, then no release is generated.
+The following is a set of guidelines for generating releases for nmdc_notebooks. This documentation is solely for the maintainers of the nmdc_notebooks repo. A release is generated within two weeks after an [nmdc-schema release](https://github.com/microbiomedata/nmdc-schema) if there have been pull requests merged into main. If there are no changes on main, then no release is generated.
 
 ## Preparing for Release
 
 ### Versioning Scheme
 This project adheres to the semantic versioning as outlined by [semver.org](https://semver.org/): MAJOR.MINOR.PATCH
 * Patch: e.g. 1.0.1 -> 1.0.2 
-   * indicates bug fixes and trivial updates
-   * fixing notebook bugs or typos are examples of patch-level changes.
+   * Indicates bug fixes and trivial updates.
+   * Fixing notebook bugs or typos are examples of patch-level changes.
 * Minor: e.g. 1.0.2 -> 1.1.0 
-   * indicates change to functionality but is still backwards compatible 
-   * examples include functionality changes, updates, adding new functionality, and potentially removing functionality depending on the degree of it.
+   * Indicates change to functionality but is still backwards compatible.
+   * Examples include functionality changes, updates, adding new functionality, and potentially removing functionality depending on the degree of it.
    * Adding new notebooks and documentation and adding functionality to notebooks (such as adding a new visual, etc.) are examples of minor changes.
 * Major: e.g. 1.1.0 -> 2.0.0 
-   * changes the introduce breaking functionality and are not backwards compatible 
-   * examples include removing deprecated code or introducing a new architecture.
+   * Changes the introduce breaking functionality and are not backwards compatible. 
+   * Examples include removing deprecated code or introducing a new architecture.
    * Major updates to the notebooks architecture (such as major api endpoints and schema traversals) and removing notebooks are considered major changes.
 
 ## Release Steps 
 Use [Github's documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to create a release by clicking on `Releases` on the repo's main page.
-1. Make a new tag when drafting a new release that follows the convention `v.1.0.0`
-2. Set the target branch to `main`
-3. Set the previous tag as the previous release number. e.g. `v.1.2.0`
+1. Make a new tag when drafting a new release that follows the convention `v.1.0.0`.
+2. Set the target branch to `main`.
+3. Set the previous tag as the previous release number. e.g. `v.1.2.0`.
 4. Generate release notes so a list of all the merge requests and contributors auto-populates.
 5. Save as draft release until ready to release or publish if ready.
    * Recommend saving as draft while updating the `CHANGELOG.md`. 
@@ -31,14 +31,14 @@ Use [Github's documentation](https://docs.github.com/en/repositories/releasing-p
 ## Post Release Steps
 * After publishing, update the `CHANGELOG.md`, create a PR with changelog updates, review, and merge.
 
-### Branching Strategy to update CHANGELOG.md
-A release branch is a branch created for preparing for the release. This is the branch used to update the CHANGELOG.md that goes with the release
-* A release branch should be named as `release-<version>`. For examples `release-v1.1.0`. 
+### Branching Strategy to Update CHANGELOG.md
+A release branch is a branch created for preparing for the release. This is the branch used to update the CHANGELOG.md that goes with the release.
+* A release branch should be named as `release-<version>`. For example `release-v1.1.0`. 
 * Update any release documentation (i.e. the CHANGELOG.md) on this branch to prepare for a release. 
-* Create a PR when ready for release
+* Create a PR when ready for release.
 
 ### Updating the CHANGELOG.md
-The `CHANGELOG.md` is formatted based on [Keep a Changelog](http://keepachangelog.com/)
+The `CHANGELOG.md` is formatted based on [Keep a Changelog](http://keepachangelog.com/).
 The change log is meant to be easily understood by humans. It is formatted with the types of changes as subheadings for each release:
 * Added
 * Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+ 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+ 
+## [Unreleased] - yyyy-mm-dd
+ 
+Here we write upgrading notes for brands. It's a team effort to make them as
+straightforward as possible.
+ 
+### Added
+- [PROJECTNAME-XXXX](http://tickets.projectname.com/browse/PROJECTNAME-XXXX)
+  MINOR Ticket title goes here.
+- [PROJECTNAME-YYYY](http://tickets.projectname.com/browse/PROJECTNAME-YYYY)
+  PATCH Ticket title goes here.
+ 
+### Changed
+ 
+### Fixed
+ 
+## [1.2.4] - 2017-03-15
+  
+Here we would have the update steps for 1.2.4 for people to follow.
+ 
+### Added
+ 
+### Changed
+  
+- [PROJECTNAME-ZZZZ](http://tickets.projectname.com/browse/PROJECTNAME-ZZZZ)
+  PATCH Drupal.org is now used for composer.
+ 
+### Fixed
+ 
+- [PROJECTNAME-TTTT](http://tickets.projectname.com/browse/PROJECTNAME-TTTT)
+  PATCH Add logic to runsheet teaser delete to delete corresponding
+  schedule cards.
+ 
+## [1.2.3] - 2017-03-14
+ 
+### Added
+   
+### Changed
+ 
+### Fixed
+ 
+- [PROJECTNAME-UUUU](http://tickets.projectname.com/browse/PROJECTNAME-UUUU)
+  MINOR Fix module foo tests
+- [PROJECTNAME-RRRR](http://tickets.projectname.com/browse/PROJECTNAME-RRRR)
+  MAJOR Module foo's timeline uses the browser timezone for date resolution 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
-## [1.0.0] - 2024-07-08
+## [v1.0.0] - 2024-07-08
  
 This is the first release of NMDC Notebooks. This release includes all 
 initial work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,47 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
-## [Unreleased] - yyyy-mm-dd
+## [1.0.0] - 2024-07-08
  
-Here we write upgrading notes for brands. It's a team effort to make them as
-straightforward as possible.
+This is the first release of NMDC Notebooks. This release includes all 
+initial work.
  
 ### Added
-- [PROJECTNAME-XXXX](http://tickets.projectname.com/browse/PROJECTNAME-XXXX)
-  MINOR Ticket title goes here.
-- [PROJECTNAME-YYYY](http://tickets.projectname.com/browse/PROJECTNAME-YYYY)
-  PATCH Ticket title goes here.
+- Two Python and R notebooks:
+   - NEON Soil Metadata
+   - Bio-Scales Biogeochemical MetaData
+- One Python only notebook:
+   - NEON Soil Microbial Community Composition
+- README.md and env requirements
+- Contributing Guidelines
+- Colab and static notebook viewing functionality
+- ReviewNB functionality to review notebooks
  
 ### Changed
  
 ### Fixed
  
-## [1.2.4] - 2017-03-15
-  
-Here we would have the update steps for 1.2.4 for people to follow.
- 
-### Added
- 
-### Changed
-  
-- [PROJECTNAME-ZZZZ](http://tickets.projectname.com/browse/PROJECTNAME-ZZZZ)
-  PATCH Drupal.org is now used for composer.
- 
-### Fixed
- 
-- [PROJECTNAME-TTTT](http://tickets.projectname.com/browse/PROJECTNAME-TTTT)
-  PATCH Add logic to runsheet teaser delete to delete corresponding
-  schedule cards.
- 
-## [1.2.3] - 2017-03-14
- 
-### Added
-   
-### Changed
- 
-### Fixed
- 
-- [PROJECTNAME-UUUU](http://tickets.projectname.com/browse/PROJECTNAME-UUUU)
-  MINOR Fix module foo tests
-- [PROJECTNAME-RRRR](http://tickets.projectname.com/browse/PROJECTNAME-RRRR)
-  MAJOR Module foo's timeline uses the browser timezone for date resolution 
+


### PR DESCRIPTION
Issue #37 

This PR includes the documentation for releases. I am guessing this will be a first go at it and we will do releases, see how we like it, adjust and iterate. I set the release cycle as every first business day of the month if there are changes to `main`. We can change this how we like. For now, the `CHANGELOG.md` is manual. There are potential tools we can use to automate this, but I'm not sure that level of automation is necessary given the nature of this repo. The release part of Github auto-generates a description of the release anyway based on the merged requests. Right now I just include an outline in the `CHANGELOG`. We will have to update/erase some of it with our first release.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Does your PR link to an issue?
* [x] Have you described the changes this PR will make?

<!-- Erase any parts of this template not applicable to your Pull Request. -->

### New Notebook Submissions:

* [ ] Have you included a summary of the notebook in the README.md included updated links to the notebook?
* [ ] Does your PR include links to the new notebook **(in the branch)** for review using [nbviewer](https://nbviewer.jupyter.org/), [Colab](https://colab.research.google.com/), and [reviewnb](https://www.reviewnb.com/)? These three are the preferred ways to review changes and additions to notebooks during review.

### Notebook Fix Submissions:

* [ ] Does your PR include links to the updated notebook **(in the branch)** for review using [nbviewer](https://nbviewer.jupyter.org/), [Colab](https://colab.research.google.com/), and [reviewnb](https://www.reviewnb.com/)? These three are the preferred ways to review changes and additions to notebooks during review.
