### PR TITLE
Cleanup: update links to `utility_functions.R` to point to main branch

### DIFF
--- a/NOM_visualizations/R/NOM_R_notebook.ipynb
+++ b/NOM_visualizations/R/NOM_R_notebook.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "metadata": {},
     "vscode": {
@@ -37,7 +37,7 @@
     "\n",
     "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") == \"\") source(\"../../utility_functions.R\")\n",
     "\n",
-    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/90-modularize-r-api-wrapper-functions/utility_functions.R\")\n"
+    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://https://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/main/utility_functions.R\")\n"
    ]
   },
   {

--- a/NOM_visualizations/R/NOM_R_notebook.ipynb
+++ b/NOM_visualizations/R/NOM_R_notebook.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") == \"\") source(\"../../utility_functions.R\")\n",
     "\n",
-    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://https://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/main/utility_functions.R\")\n"
+    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/main/utility_functions.R\")\n"
    ]
   },
   {

--- a/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb
+++ b/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "568d7112-ee43-41ce-aadb-39eaa9585dbd",
    "metadata": {
     "metadata": {},
@@ -31,7 +31,7 @@
     "\n",
     "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") == \"\") source(\"../../utility_functions.R\")\n",
     "\n",
-    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/90-modularize-r-api-wrapper-functions/utility_functions.R\")"
+    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://https://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/main/utility_functions.R\")"
    ]
   },
   {

--- a/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb
+++ b/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") == \"\") source(\"../../utility_functions.R\")\n",
     "\n",
-    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://https://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/main/utility_functions.R\")"
+    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") source(\"http://raw.githubusercontent.com/microbiomedata/nmdc_notebooks/refs/heads/main/utility_functions.R\")"
    ]
   },
   {


### PR DESCRIPTION
This PR cleans up after https://github.com/microbiomedata/nmdc_notebooks/pull/103. It updates the path which the notebooks use to download the new R API function script to point to the main branch, now that 103 has been merged and the script exists in main.

Edited notebooks in this branch
----------
NOM notebook in nbviewer and colab:

https://nbviewer.org/github/microbiomedata/nmdc_notebooks/blob/134-cleanup-change-utility_functionsr-links-back-to-main-branch/NOM_visualizations/R/NOM_R_notebook.ipynb

https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/134-cleanup-change-utility_functionsr-links-back-to-main-branch/NOM_visualizations/R/NOM_R_notebook.ipynb

----------
Taxonomy notebook in colab:

https://nbviewer.org/github/microbiomedata/nmdc_notebooks/blob/134-cleanup-change-utility_functionsr-links-back-to-main-branch/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb

https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/134-cleanup-change-utility_functionsr-links-back-to-main-branch/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb

--------


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/microbiomedata/nmdc_notebooks/blob/main/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/microbiomedata/nmdc_notebooks/pulls) for the same update/change?
* [x] Does your PR link to an issue?
* [x] Have you described the changes this PR will make?

### Notebook Fix Submissions:

* [x] Does your PR include links to the updated notebook **(in the branch)** for review using [nbviewer](https://nbviewer.jupyter.org/), [Colab](https://colab.research.google.com/), and [reviewnb](https://www.reviewnb.com/)? These three are the preferred ways to review changes and additions to notebooks during review.
