### PR TITLE
Update README and notebook links in omics_types_integration to point to main

### DIFF
--- a/omics_types_integration/R/integration_notebook.ipynb
+++ b/omics_types_integration/R/integration_notebook.ipynb
@@ -1707,8 +1707,7 @@
    },
    "outputs": [],
    "source": [
-    "## TODO update this URL to main after merging\n",
-    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") download.file(url = \"https://github.com/microbiomedata/nmdc_notebooks/blob/91-create-notebook-integrating-metag-metap-metab-data-r/omics_types_integration/R/ko00710.pathview.png\")"
+    "if(Sys.getenv(\"COLAB_BACKEND_VERSION\") != \"\") download.file(url = \"https://github.com/microbiomedata/nmdc_notebooks/blob/main/omics_types_integration/R/ko00710.pathview.png\")"
    ]
   },
   {

--- a/omics_types_integration/README.md
+++ b/omics_types_integration/README.md
@@ -3,7 +3,6 @@
 This folder includes two notebooks (in R and Python) that illustrate how metagenomic, metaproteomic, and metabolomic data from the same sample can be retrieved from the [NMDC-runtime API](https://api.microbiomedata.org/docs) and integrated using KEGG annotations.
 
 ## R 
-### TODO update links once the branch is merged into main
 - [Static rendered Jupyter notebook](https://nbviewer.org/github/microbiomedata/nmdc_notebooks/blob/main/omics_types_integration/R/integration_notebook.ipynb). This is the recommended way to interact with the notebook. _Viewing only, not editable_
 - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/main/omics_types_integration/R/integration_notebook.ipynb). **Running this notebook in the colab interactive environment is not recommended due to long API calls** _You need a google account to use this option_
 

--- a/omics_types_integration/README.md
+++ b/omics_types_integration/README.md
@@ -4,8 +4,8 @@ This folder includes two notebooks (in R and Python) that illustrate how metagen
 
 ## R 
 ### TODO update links once the branch is merged into main
-- [Static rendered Jupyter notebook](https://nbviewer.org/github/microbiomedata/nmdc_notebooks/blob/91-create-notebook-integrating-metag-metap-metab-data-r/omics_types_integration/R/integration_notebook.ipynb). This is the recommended way to interact with the notebook. _Viewing only, not editable_
-- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/91-create-notebook-integrating-metag-metap-metab-data-r/omics_types_integration/R/integration_notebook.ipynb). **Running this notebook in the colab interactive environment is not recommended due to long API calls** _You need a google account to use this option_
+- [Static rendered Jupyter notebook](https://nbviewer.org/github/microbiomedata/nmdc_notebooks/blob/main/omics_types_integration/R/integration_notebook.ipynb). This is the recommended way to interact with the notebook. _Viewing only, not editable_
+- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/main/omics_types_integration/R/integration_notebook.ipynb). **Running this notebook in the colab interactive environment is not recommended due to long API calls** _You need a google account to use this option_
 
 ## Python
 Coming soon!


### PR DESCRIPTION
Follow up to https://github.com/microbiomedata/nmdc_notebooks/pull/124 being merged in, update the links to point to the notebook in the main branch now that the dev branch has been merged and deleted.