### PR TITLE
Modify workflow to specify R version

### DIFF
--- a/.github/workflows/notebook_check_r.yml
+++ b/.github/workflows/notebook_check_r.yml
@@ -31,7 +31,7 @@ jobs:
       name: Set up R
       uses: r-lib/actions/setup-r@v2
       with:
-      r-version: '4.4'
+        r-version: '4.4.3'
 
     - name: dependencies on Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/notebook_check_r.yml
+++ b/.github/workflows/notebook_check_r.yml
@@ -30,6 +30,8 @@ jobs:
     - id: r-setup
       name: Set up R
       uses: r-lib/actions/setup-r@v2
+      with:
+      r-version: '4.4'
 
     - name: dependencies on Linux
       if: runner.os == 'Linux'


### PR DESCRIPTION
This PR will close #170 by modifying the github action to use a specific version of R (4.4.3).  Before it was defaulting to using the very newest version of R (4.5 atm), but not all packages were compatible.  

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/microbiomedata/nmdc_notebooks/blob/main/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/microbiomedata/nmdc_notebooks/pulls) for the same update/change?
* [x] Does your PR link to an issue?
* [x] Have you described the changes this PR will make?
