### PR TITLE
Limit dataset downloads and select specific workflow version for taxonomy notebook (R)

### DIFF
--- a/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb
+++ b/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# How does the taxonomic distribution of contigs differ by soil layer (mineral vs organic) in Colorado?\n",
     "\n",
-    "This notebook uses the NMDC API endpoints to explore how the taxononomic distribution of metagenome contigs differ by the mineral and organic soil layers in Colorado. It involves 9 API requests to reach the scaffold lineage TSV data objects in order to analyze the taxanomic distribution. Iterating through the TSV files includes 100+ API calls to get the necessary taxonomic counts and is time consuming. "
+    "This notebook uses the NMDC API endpoints to explore how the taxonomic distribution of metagenome contigs differ by the mineral and organic soil layers in Colorado. It involves 9 API requests to reach the scaffold lineage TSV data objects in order to analyze the taxanomic distribution. Downloading the taxonomic results files may be time consuming. "
    ]
   },
   {


### PR DESCRIPTION
This PR adds improvements to the "Taxonomic distribution by soil layer" R notebook:

- Limit the number of files being downloaded by randomly selecting a set number of samples per soil horizon (Fixes #218 )
- Filter to a specific version of metagenome annotation records to avoid duplicate records per sample and ensure consistency



------------------------------
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/microbiomedata/nmdc_notebooks/blob/main/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/microbiomedata/nmdc_notebooks/pulls) for the same update/change?
* [x] Does your PR link to an issue?
* [x] Have you described the changes this PR will make?

### Notebook Fix Submissions:
* [x] Does your PR include links to the updated notebook **(in the branch)** for review using [nbviewer](https://nbviewer.jupyter.org/), and [Colab](https://colab.research.google.com/)? These are the preferred ways to review changes and additions to notebooks during review. See the guidance below for how to create these links.

----------------
https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/218-add-limit-to-the-number-of-datasets-being-downloaded-in-taxonomic-notebook-r/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb

https://nbviewer.org/github/microbiomedata/nmdc_notebooks/blob/218-add-limit-to-the-number-of-datasets-being-downloaded-in-taxonomic-notebook-r/taxonomic_dist_by_soil_layer/R/taxonomic_dist_soil_layer_R.ipynb