### PR TITLE
Fix duplicated row error in R integration notebook

### DIFF
--- a/omics_types_integration/R/integration_r.ipynb
+++ b/omics_types_integration/R/integration_r.ipynb
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "vscode": {
      "languageId": "r"
@@ -358,7 +358,8 @@
     "            \"Annotation KEGG Orthology\" %in% data_object_type &\n",
     "            \"GC-MS Metabolomics Results\" %in% data_object_type &\n",
     "            \"Protein Report\" %in% data_object_type) %>%\n",
-    "    ungroup()\n",
+    "    ungroup() %>%\n",
+    "    distinct()\n",
     "    \n",
     "\n",
     "# How many biosamples have all three omics types?\n",


### PR DESCRIPTION
This PR fixes #254 by removing duplicate rows in a dataframe of data objects for the study which was causing an error and preventing the workflows from running.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/microbiomedata/nmdc_notebooks/blob/main/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/microbiomedata/nmdc_notebooks/pulls) for the same update/change?
* [x] Does your PR link to an issue?
* [x] Have you described the changes this PR will make?

### Notebook Fix Submissions:
* [x] Does your PR include links to the updated notebook **(in the branch)** for review using [Colab](https://colab.research.google.com/)? These are the preferred ways to review changes and additions to notebooks during review. See the guidance below for how to create these links.

https://colab.research.google.com/github/microbiomedata/nmdc_notebooks/blob/254-fix-integration-r-notebook/omics_types_integration/R/integration_r.ipynb