### PR TITLE
Upgrade and pin third-party actions using commit hashes

### DIFF
--- a/.github/actions/setup-r-environment-v2/action.yml
+++ b/.github/actions/setup-r-environment-v2/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "RENV_PATHS_ROOT=$HOME/.local/share/renv/cache" >> $GITHUB_ENV
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
@@ -44,7 +44,7 @@ runs:
         pip install jupyter
 
     - name: Cache system packages
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: /var/cache/apt
         key: ${{ runner.os }}-apt-packages-r
@@ -52,7 +52,7 @@ runs:
           ${{ runner.os }}-apt-packages-
 
     - name: Set up R
-      uses: r-lib/actions/setup-r@v2
+      uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2
       with:
         r-version: ${{ inputs.r-version }}
         use-public-rspm: true
@@ -112,7 +112,7 @@ runs:
         echo "cache-key=$cache_key" >> $GITHUB_OUTPUT
 
     - name: Cache R packages
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ${{ env.RENV_PATHS_ROOT }}

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -25,11 +25,11 @@ jobs:
       notebooks: ${{ steps.set-notebooks.outputs.notebooks }}
     steps:
     - id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - id: python-setup
       name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
@@ -41,7 +41,7 @@ jobs:
         pip install jupyter nbconvert
 
     - name: Cache Python dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -64,7 +64,7 @@ jobs:
       cache-key: ${{ steps.setup-r-env.outputs.cache-key }}
     steps:
     - id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - id: setup-r-env
       name: Set up R environment
@@ -91,16 +91,16 @@ jobs:
       
     steps:
     - id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - id: python-setup
       name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
     - name: Restore Python dependencies cache
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -142,14 +142,14 @@ jobs:
         fi
 
     - name: Upload HTML artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
       with:
         name: html-python-${{ matrix.notebook.name }}
         path: html_output/*.html
 
     - name: Upload results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: notebook-results-python-${{ matrix.notebook.name }}
@@ -167,7 +167,7 @@ jobs:
     
     steps:
     - id: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Activate R environment (fast)
       uses: ./.github/actions/setup-r-environment-v2
@@ -214,14 +214,14 @@ jobs:
         fi
 
     - name: Upload HTML artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
       with:
         name: html-r-${{ matrix.notebook.name }}
         path: html_output/*.html
 
     - name: Upload results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: notebook-results-r-${{ matrix.notebook.name }}
@@ -236,10 +236,10 @@ jobs:
       all-successful: ${{ steps.check.outputs.all-successful }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Gather all notebook results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: results/
 
@@ -284,10 +284,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Download all HTML artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: html-artifacts/
 
@@ -525,13 +525,13 @@ jobs:
         EOF
 
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: '_site'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/link_check_chron.yml
+++ b/.github/workflows/link_check_chron.yml
@@ -13,18 +13,18 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --retry-wait-time 10 './**/*.md'
           
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/notebook-test-r-reusable.yml
+++ b/.github/workflows/notebook-test-r-reusable.yml
@@ -34,7 +34,7 @@ jobs:
       notebooks: ${{ steps.set-notebooks.outputs.notebooks }}
       has-notebooks: ${{ steps.set-notebooks.outputs.has-notebooks }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -136,7 +136,7 @@ jobs:
       r-version: ${{ steps.setup-r.outputs.r-version }}
       cache-key: ${{ steps.setup-r.outputs.cache-key }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up R environment (full)
       id: setup-r
@@ -154,7 +154,7 @@ jobs:
       matrix:
         notebook: ${{ fromJson(needs.detect-notebooks.outputs.notebooks) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Create result placeholder
       run: |
@@ -186,7 +186,7 @@ jobs:
         fi
 
     - name: Upload results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: notebook-results-r-${{ matrix.notebook.name }}
@@ -194,7 +194,7 @@ jobs:
 
     - name: Upload notebook
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: result-r-${{ matrix.notebook.name }}
         path: ${{ matrix.notebook.path }}
@@ -205,7 +205,7 @@ jobs:
     if: always() && needs.detect-notebooks.outputs.has-notebooks == 'true'
     steps:
     - name: Gather all notebook results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: results/
 

--- a/.github/workflows/notebook-test-reusable.yml
+++ b/.github/workflows/notebook-test-reusable.yml
@@ -34,7 +34,7 @@ jobs:
       notebooks: ${{ steps.set-notebooks.outputs.notebooks }}
       has-notebooks: ${{ steps.set-notebooks.outputs.has-notebooks }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
@@ -128,10 +128,10 @@ jobs:
       python-version: ${{ steps.get-version.outputs.python-version }}
       requirements-hash: ${{ steps.get-version.outputs.requirements-hash }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
@@ -144,7 +144,7 @@ jobs:
         echo "requirements-hash=$requirements_hash" >> $GITHUB_OUTPUT
 
     - name: Cache Python packages
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -169,10 +169,10 @@ jobs:
       matrix:
         notebook: ${{ fromJson(needs.detect-notebooks.outputs.notebooks) }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     
     - name: Set up Python (fast)
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
@@ -186,7 +186,7 @@ jobs:
         fi
 
     - name: Restore Python packages cache (fast)
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -242,7 +242,7 @@ jobs:
         fi
 
     - name: Upload results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: notebook-results-${{ matrix.notebook.name }}
@@ -250,7 +250,7 @@ jobs:
 
     - name: Upload notebook
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: result-${{ matrix.notebook.name }}
         path: ${{ matrix.notebook.path }}
@@ -261,7 +261,7 @@ jobs:
     if: always() && needs.detect-notebooks.outputs.has-notebooks == 'true'
     steps:
     - name: Gather all notebook results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: results/
 


### PR DESCRIPTION
These changes implement the recommend security hardening step of [pinning third party actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) using commit hashes. They also do an upgrade to avoid using [deprecated Node 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

---

Implementation note: these changes were automatically generated with [pinact](https://github.com/suzuki-shunsuke/pinact):
```
pinact run --update --min-age 7
```
